### PR TITLE
Update to 1.3, change ncurses wrapper API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,12 @@
 [root]
 name = "rusty_bars"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 
 name = "rusty_bars"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Paul Furtado <paulfurtado91@gmail.com>"]
 
 
 [dependencies]
-libc = "0.1.8"
+libc = "0.1.10"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ FFTW library, and displays the visual using ncurses.
 
 Building
 --------
-Simply run "cargo build" using rust 1.0.
+Simply run "cargo build" using rust 1.3.
 This project depends on libpulse, ncurses, and FFTW, however these packages
 are likely already installed on any desktop linux distribution.
 

--- a/src/fftw/ext.rs
+++ b/src/fftw/ext.rs
@@ -1,4 +1,3 @@
-
 extern crate libc;
 use self::libc::{c_int, size_t, c_void};
 use fftw::types::*;

--- a/src/fftw/ext.rs
+++ b/src/fftw/ext.rs
@@ -2,14 +2,16 @@ extern crate libc;
 use self::libc::{c_int, size_t, c_void};
 use fftw::types::*;
 
+/// An opaque pointer to an FFTW C plan
+pub enum FftwPlan {}
 
 #[link(name="fftw3")]
 extern {
     /// Creates a 1-dimensional real-to-complex FFT plan
-    pub fn fftw_plan_dft_r2c_1d(n: c_int, input: *mut f64, output: *mut FftwComplex, flags: PlannerFlags) -> *mut fftw_plan;
+    pub fn fftw_plan_dft_r2c_1d(n: c_int, input: *mut f64, output: *mut FftwComplex, flags: PlannerFlags) -> *mut FftwPlan;
 
     /// Executes an FFTW plan
-    pub fn fftw_execute(plan: *const fftw_plan);
+    pub fn fftw_execute(plan: *const FftwPlan);
 
     /// Performs a proper-aligned malloc
     pub fn fftw_malloc(n: size_t) -> *mut c_void;
@@ -18,5 +20,5 @@ extern {
     pub fn fftw_free(ptr: *mut c_void);
 
     /// Destroy an fftw plan. Should be called when done with a plan.
-    pub fn fftw_destroy_plan(plan: *mut fftw_plan);
+    pub fn fftw_destroy_plan(plan: *mut FftwPlan);
 }

--- a/src/fftw/hanning.rs
+++ b/src/fftw/hanning.rs
@@ -1,4 +1,3 @@
-
 use std::f64::consts::PI;
 //use std::num::Float;
 

--- a/src/fftw/plan.rs
+++ b/src/fftw/plan.rs
@@ -1,8 +1,7 @@
-
 extern crate libc;
-use fftw::types::*;
+use fftw::types::{FftwComplex, PlannerFlags};
 use fftw::ext;
-use fftw::aligned_array::*;
+use fftw::aligned_array::FftwAlignedArray;
 
 
 /// Rust wrapper for an FFTW plan
@@ -10,7 +9,7 @@ pub struct FftwPlan {
     input: FftwAlignedArray<f64>,
     output: FftwAlignedArray<FftwComplex>,
     size: usize,
-    plan: *mut fftw_plan,
+    plan: *mut ext::FftwPlan,
 }
 
 

--- a/src/fftw/types.rs
+++ b/src/fftw/types.rs
@@ -1,11 +1,5 @@
-
 #[repr(C)]
-/// An opaque pointer to an FFTW C plan
-pub struct fftw_plan;
-
-
-#[repr(C)]
-/// Thse can be found in fftw/api/fftw2.h in the FFW source. In FFTW, they are
+/// These can be found in fftw/api/fftw2.h in the FFTW source. In FFTW, they are
 /// defined with #define.
 /// You can read more about planner flags here:
 /// http://www.fftw.org/doc/Planner-Flags.html
@@ -29,6 +23,7 @@ pub struct FftwComplex {
     pub re: f64,
     pub im: f64
 }
+
 
 impl FftwComplex {
     /// Get the absolute value (distance from zero) of the complex number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod ncurses_wrapper;
+pub mod ncurses;
 pub mod pulse;
 pub mod visualizer;
 pub mod fftw;

--- a/src/ncurses/ext.rs
+++ b/src/ncurses/ext.rs
@@ -1,0 +1,19 @@
+extern crate libc;
+use self::libc::{c_int, c_char};
+
+/// Module for external ncurses functions and types
+
+#[repr(C)]
+pub struct WINDOW;
+
+#[link(name="ncurses")]
+extern {
+    pub fn initscr() -> *mut WINDOW;
+    pub fn endwin() -> c_int;
+    pub fn wrefresh(win: *mut WINDOW) -> c_int;
+    pub fn mvwaddstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char) -> c_int;
+    pub fn mvwaddnstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char, n: c_int) -> c_int;
+    pub fn getmaxy(win: *mut WINDOW) -> c_int;
+    pub fn getmaxx(win: *mut WINDOW) -> c_int;
+    pub fn curs_set(visibility: c_int) -> c_int;
+}

--- a/src/ncurses/ext.rs
+++ b/src/ncurses/ext.rs
@@ -3,17 +3,18 @@ use self::libc::{c_int, c_char};
 
 /// Module for external ncurses functions and types
 
-#[repr(C)]
-pub struct WINDOW;
+// An opaque pointer to an ncurses window representation.
+pub enum Window {}
+
 
 #[link(name="ncurses")]
 extern {
-    pub fn initscr() -> *mut WINDOW;
+    pub fn initscr() -> *mut Window;
     pub fn endwin() -> c_int;
-    pub fn wrefresh(win: *mut WINDOW) -> c_int;
-    pub fn mvwaddstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char) -> c_int;
-    pub fn mvwaddnstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char, n: c_int) -> c_int;
-    pub fn getmaxy(win: *mut WINDOW) -> c_int;
-    pub fn getmaxx(win: *mut WINDOW) -> c_int;
+    pub fn wrefresh(win: *mut Window) -> c_int;
+    pub fn mvwaddstr(win: *mut Window, y: c_int, x: c_int, text: *const c_char) -> c_int;
+    pub fn mvwaddnstr(win: *mut Window, y: c_int, x: c_int, text: *const c_char, n: c_int) -> c_int;
+    pub fn getmaxy(win: *mut Window) -> c_int;
+    pub fn getmaxx(win: *mut Window) -> c_int;
     pub fn curs_set(visibility: c_int) -> c_int;
 }

--- a/src/ncurses/mod.rs
+++ b/src/ncurses/mod.rs
@@ -1,0 +1,2 @@
+mod ext;
+pub mod window;

--- a/src/ncurses/window.rs
+++ b/src/ncurses/window.rs
@@ -12,16 +12,16 @@ pub fn endwin() -> Result<(), c_int> {
     let result = unsafe{ ext::endwin() };
     if result == 0 {
         return Ok(())
-    }
-    else {
+    } else {
         return Err(result)
     }
 }
 
+
 /// Wraps an ncruses WINDOW struct with the basic functions for manipulating
 /// the window.
 pub struct Window {
-    w: *mut ext::WINDOW
+    w: *mut ext::Window
 }
 
 
@@ -76,6 +76,12 @@ impl Window {
     /// Set the visibility of the cursor
     pub fn curs_set(&mut self, visibility: c_int) -> Result<c_int, c_int> {
         handle_err(unsafe{ ext::curs_set(visibility) })
+    }
+}
+
+impl Drop for Window {
+    fn drop(&mut self) {
+        endwin().unwrap();
     }
 }
 

--- a/src/ncurses/window.rs
+++ b/src/ncurses/window.rs
@@ -18,6 +18,17 @@ pub fn endwin() -> Result<(), c_int> {
 }
 
 
+/// Initialize the screen and get a window
+fn initscr() -> Result<Window, c_int> {
+    let window = unsafe { ext::initscr() };
+    if window.is_null() {
+        Err(-1)
+    } else {
+        Ok(Window { w: window })
+    }
+}
+
+
 /// Wraps an ncruses WINDOW struct with the basic functions for manipulating
 /// the window.
 pub struct Window {
@@ -26,15 +37,8 @@ pub struct Window {
 
 
 impl Window {
-    /// Initialize the screen and get a window
-    pub fn initscr() -> Result<Window, c_int> {
-        let window = unsafe{ ext::initscr() };
-        if window.is_null() {
-            Err(-1)
-        }
-        else {
-            Ok(Window{w: window})
-        }
+    pub fn new() -> Window {
+        initscr().unwrap()
     }
 
     /// Add a string to the screen starting at the given location

--- a/src/ncurses/window.rs
+++ b/src/ncurses/window.rs
@@ -1,9 +1,9 @@
 #![allow(missing_copy_implementations)]
-
 extern crate libc;
 
 use std::ffi::CString;
 use self::libc::{c_int, c_char};
+use ncurses::ext;
 
 
 /// Safe wrapper for the ncurses endwin function. Call this when you are done
@@ -86,28 +86,5 @@ fn handle_err(result: c_int) -> Result<c_int, c_int> {
         Err(result)
     } else {
         Ok(result)
-    }
-}
-
-
-mod ext {
-    /// Module for external ncurses functions and types
-
-    extern crate libc;
-    use self::libc::{c_int, c_char};
-
-    #[repr(C)]
-    pub struct WINDOW;
-
-    #[link(name="ncurses")]
-    extern {
-        pub fn initscr() -> *mut WINDOW;
-        pub fn endwin() -> c_int;
-        pub fn wrefresh(win: *mut WINDOW) -> c_int;
-        pub fn mvwaddstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char) -> c_int;
-        pub fn mvwaddnstr(win: *mut WINDOW, y: c_int, x: c_int, text: *const c_char, n: c_int) -> c_int;
-        pub fn getmaxy(win: *mut WINDOW) -> c_int;
-        pub fn getmaxx(win: *mut WINDOW) -> c_int;
-        pub fn curs_set(visibility: c_int) -> c_int;
     }
 }

--- a/src/pulse/types.rs
+++ b/src/pulse/types.rs
@@ -57,22 +57,14 @@ pub mod cb {
 /// For types we only have pointers to. Use structs with names so there is at
 /// least pointer type safety.
 pub mod opaque {
-    #[repr(C)]
-    pub struct pa_mainloop;
-    #[repr(C)]
-    pub struct pa_mainloop_api;
-    #[repr(C)]
-    pub struct pa_context;
-    #[repr(C)]
-    pub struct pa_spawn_api;
-    #[repr(C)]
-    pub struct pa_threaded_mainloop;
-    #[repr(C)]
-    pub struct pa_proplist;
-    #[repr(C)]
-    pub struct pa_stream;
-    #[repr(C)]
-    pub struct pa_operation;
+    pub enum pa_mainloop {}
+    pub enum pa_mainloop_api {}
+    pub enum pa_context {}
+    pub enum pa_spawn_api {}
+    pub enum pa_threaded_mainloop {}
+    pub enum pa_proplist {}
+    pub enum pa_stream {}
+    pub enum pa_operation {}
 }
 
 /// For enum types

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -208,14 +208,4 @@ impl Visualizer {
 }
 
 
-impl Drop for Visualizer {
-    /// Call endwin to clean up the termninal when the Visualizer is dallocated
-    fn drop(&mut self) {
-        match endwin() {
-            _ => {}
-        };
-    }
-}
-
-
 unsafe impl Send for Visualizer {}

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 use self::libc::{c_int, c_char};
-use ncurses_wrapper::{Window,endwin};
+use ncurses::window::{Window,endwin};
 
 /// The character to use for a bar
 const BAR_CHAR: c_char = '|' as c_char;

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -1,24 +1,27 @@
 extern crate libc;
 
 use self::libc::{c_int, c_char};
-use ncurses::window::{Window,endwin};
+use ncurses::window::Window;
+
 
 /// The character to use for a bar
 const BAR_CHAR: c_char = '|' as c_char;
 
+
 /// The character to use for rows above the bar
 const EMPTY_CHAR: c_char = ' ' as c_char;
+
 
 /// The character to use where there is a lack of data due to scaling issues.
 /// (If the user sees this character, it is because the visualizer wasn't
 /// properly scaled to the window width)
 const BORDER_CHAR: c_char = ' ' as c_char;
 
+
 /// The character to initialize the row arrays with.
 /// (This is not the same as EMPTY_CHAR so that it is easy to detect that we
 /// didn't draw some part of the screen. Users should never see this.)
 const INIT_CHAR: c_char = '#' as c_char;
-
 
 
 /// Scales down a vector by averaging the elements between the resulting points
@@ -98,10 +101,7 @@ pub struct Visualizer{
 impl Visualizer {
     /// Instantiate a new visualizer. Takes over the terminal with ncurses.
     pub fn new() -> Visualizer {
-        let mut win = match Window::initscr() {
-            Err(_) => panic!("Failed to initialize screen!"),
-            Ok(win) => win
-        };
+        let mut win = Window::new();
 
         // Disable the cursor so it's not moving all around the screen when the
         // animation is rendering.


### PR DESCRIPTION
Updated to build with Rust 1.3, which mostly involved clearing warnings on the opaque pointer types in the FFI bindings.

Also changed the safe/wrapper ncurses Window API to:
- initialize an ncurses screen when a Window is created (in the constructor)
- clean up the terminal state when the Window falls out of scope (in the Drop trait implementation)

which seems like a simpler (more Rust-like?) API since multiple screens aren't supported yet.
