### PR TITLE
Fix warnings with Rust 1.6

### DIFF
--- a/src/fftw/audio.rs
+++ b/src/fftw/audio.rs
@@ -1,4 +1,3 @@
-
 use std::slice;
 //use std::num::Float;
 use fftw::multichannel::MultiChannelFft;
@@ -31,7 +30,7 @@ impl AudioFft {
     /// Create a new AudioFft
     pub fn new(fft_size: usize, channel_count: usize) -> AudioFft {
         let mut out_vec = Vec::with_capacity(fft_size/2);
-        for _ in (0..fft_size/2) {
+        for _ in 0..fft_size/2 {
             out_vec.push(0.0);
         }
         AudioFft {

--- a/src/fftw/hanning.rs
+++ b/src/fftw/hanning.rs
@@ -16,7 +16,7 @@ impl HanningWindowCalculator {
         let mut multipliers: Vec<f64> = Vec::with_capacity(fft_size);
         let divider: f64 = (fft_size - 1) as f64;
 
-        for i in (0..fft_size) {
+        for i in 0..fft_size {
             let cos_inner: f64 = 2.0 * PI * (i as f64) / divider;
             let cos_part: f64 = cos_inner.cos();
             let multiplier: f64 = 0.5 * (1.0 - cos_part);

--- a/src/fftw/multichannel.rs
+++ b/src/fftw/multichannel.rs
@@ -17,7 +17,7 @@ impl MultiChannelFft {
     pub fn new(size: usize, channel_count: usize) -> MultiChannelFft {
         let mut channel_plans: Vec<FftwPlan> = Vec::with_capacity(channel_count);
 
-        for _ in (0..channel_count) {
+        for _ in 0..channel_count {
             channel_plans.push(FftwPlan::new(size));
         }
         channel_plans.shrink_to_fit();


### PR DESCRIPTION
Fixes unnecessary parentheses warnings from rustc 1.6.0-nightly (8ca0acc25 2015-10-28).
Should be moved in after https://github.com/PaulFurtado/rusty_bars/pull/2

```
src/fftw/multichannel.rs:20:18: 20:36 warning: unnecessary parentheses around `for` head expression, #[warn(unused_parens)] on by default
src/fftw/multichannel.rs:20         for _ in (0..channel_count) {
                                             ^~~~~~~~~~~~~~~~~~
src/fftw/audio.rs:34:18: 34:33 warning: unnecessary parentheses around `for` head expression, #[warn(unused_parens)] on by default
src/fftw/audio.rs:34         for _ in (0..fft_size/2) {
                                      ^~~~~~~~~~~~~~~
src/fftw/hanning.rs:18:18: 18:31 warning: unnecessary parentheses around `for` head expression, #[warn(unused_parens)] on by default
src/fftw/hanning.rs:18         for i in (0..fft_size) {
                                        ^~~~~~~~~~~~~
```
